### PR TITLE
Run separate tests in a test plan

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 Release 0.4.0-dev
 ---------------------------------
+* Add option --only for 'run' command (@flipback)
 * Add command 'validate' to check format of all the test on QA directory (@flipback)
 * #11 Fix validation error in command list (@flipback)
 * Nitpicker can be run as a command (`nitpicker` instead of `python -m nitpicker) (@flipback)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 Release 0.4.0-dev
 ---------------------------------
-* Add option --only for 'run' command (@flipback)
+* Add flag --only for 'run' command (@flipback)
 * Add command 'validate' to check format of all the test on QA directory (@flipback)
 * #11 Fix validation error in command list (@flipback)
 * Nitpicker can be run as a command (`nitpicker` instead of `python -m nitpicker) (@flipback)

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -11,6 +11,7 @@ the following options:
 * **no_editor** - if set in *true*, a new test is not opened in a text editor after command 'add' (default: false)
 * **cvs** - the type of CVS, currently only git is supported (default: 'git')
 * **main_branch** - the main branch, where all new feature branch are to merge (default: 'master'). See :ref:`ci` for more information.
+* **debug** - if set in *true* all commands run in debug mode with a lot of messages
 
 A setting file's example:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -10,7 +10,7 @@ the following options:
 * **qa_dir** - the relative path of QA directory inside the project (default: 'qa')
 * **no_editor** - if set in *true*, a new test is not opened in a text editor after command 'add' (default: false)
 * **cvs** - the type of CVS, currently only git is supported (default: 'git')
-* **main_branch** - the main branch, where all new feature branch are to merge (default: 'master'). See :ref:`ci` for more information.
+* **main_branch** - the main branch, where all new feature branch are to merge into(default: 'master'). See :ref:`ci` for more information.
 * **debug** - if set in *true* all commands run in debug mode with a lot of messages
 
 A setting file's example:

--- a/features/run.feature
+++ b/features/run.feature
@@ -1,20 +1,20 @@
 Feature: Run a test plan
 
-    Scenario: A report has all cases passed
+    Scenario: A run report has all cases passed
         Given there is "test_plan" with 2 cases
         When we input command "run test_plan"
         And pass all steps of all cases
         Then we got a report in "test_plan/runs"
         And the report has 2 case(s) passed
 
-    Scenario: A report has one case skipped
+    Scenario: A run report has one case skipped
         Given there is "test_plan" with 2 cases
         When we input command "run test_plan"
         And skip a case
         Then we got a report in "test_plan/runs"
         And the report has 1 case(s) skipped
 
-    Scenario: A report has one case failed
+    Scenario: A run report has one case failed
         Given there is "test_plan" with 2 cases
         When we input command "run test_plan"
         And fail 2 step of 1 case
@@ -53,3 +53,11 @@ Feature: Run a test plan
         Then we got a report in "test_plan/runs"
         And the report has "tester" equals "Mr. Hankey"
         And the report has "email" equals "mrhankey@gmail.com"
+
+    Scenario: A user run only specified tests
+        Given there is "test_plan" with 2 cases
+        When we input command "run test_plan"
+        And option -o is set with "new_case_1"
+        And pass all steps of all cases
+        Then we got a report in "test_plan/runs"
+        And the report has 1 case(s) passed

--- a/nitpicker/__init__.py
+++ b/nitpicker/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from nitpicker.nitpicker import main
 from nitpicker.nitpicker import __version__
 from nitpicker.nitpicker import __cvs_factory__

--- a/nitpicker/__main__.py
+++ b/nitpicker/__main__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import nitpicker
 
 nitpicker.main()

--- a/nitpicker/commands/run_command_handler.py
+++ b/nitpicker/commands/run_command_handler.py
@@ -42,7 +42,7 @@ class RunCommandHandler:
 
         for qa_dir, _, cases in os.walk(case_dir):
             self.debug('Look for test cases in  {}', qa_dir)
-            cases = [c for c in cases if '.yml' in c]
+            cases = sorted((c for c in cases if '.yml' in c), reverse=False)
 
             if len(cases) == 0:
                 self.debug('Found no cases')

--- a/nitpicker/commands/run_command_handler.py
+++ b/nitpicker/commands/run_command_handler.py
@@ -10,7 +10,7 @@ class RunCommandHandler:
     """
     Implements 'run' command
     """
-    def __init__(self, qa_dir, cvs_adapter, test_plan, report_dir, only=None, debug=False):
+    def __init__(self, qa_dir, cvs_adapter, test_plan, report_dir, debug=False):
         """
         :param qa_dir: The QA dir where it searches runs
         :param cvs_adapter: CVS adapter to access to Repo
@@ -23,20 +23,20 @@ class RunCommandHandler:
         self.__cvs_adapter = cvs_adapter
         self.__test_plan = test_plan
         self.__report_dir = report_dir
-        self.__only = only
         self.__debug = debug
 
-    def run_test_cases(self):
+    def run_test_cases(self, only):
         """
         Runs a test plan
+        :param only: The list of the test cases which should be run separated by comma
         :return: None
         """
         case_dir = os.path.join(*([self.__qa_dir] + self.__test_plan.split('.')))
         self.debug('Get the case dir {}', case_dir)
 
         only_cases = None
-        if self.__only is not None and len(self.__only) > 0:
-            only_cases = [c + '.yml' for c in self.__only.split(',')]
+        if only is not None and len(only) > 0:
+            only_cases = [c + '.yml' for c in only.split(',')]
             self.debug('Only option is on')
             self.debug('Run only {}', only_cases)
 

--- a/nitpicker/commands/run_command_handler.py
+++ b/nitpicker/commands/run_command_handler.py
@@ -10,17 +10,21 @@ class RunCommandHandler:
     """
     Implements 'run' command
     """
-    def __init__(self, qa_dir, cvs_adapter, test_plan, report_dir):
+    def __init__(self, qa_dir, cvs_adapter, test_plan, report_dir, only=None, debug=False):
         """
         :param qa_dir: The QA dir where it searches runs
         :param cvs_adapter: CVS adapter to access to Repo
         :param test_plan: the test plan to run
         :param report_dir: The dir where the QA report is generated
+        :param report_dir: The list of cases in the plan to run. If it is None or '', all test are run
+        :param report_dir: debug flag
         """
         self.__qa_dir = qa_dir
         self.__cvs_adapter = cvs_adapter
         self.__test_plan = test_plan
         self.__report_dir = report_dir
+        self.__only = only
+        self.__debug = debug
 
     def run_test_cases(self):
         """
@@ -28,34 +32,55 @@ class RunCommandHandler:
         :return: None
         """
         case_dir = os.path.join(*([self.__qa_dir] + self.__test_plan.split('.')))
+        self.debug('Get the case dir {}', case_dir)
 
-        for qa_dir, _, files in os.walk(case_dir):
-            files = [f for f in files if '.yml' in f]
-            if len(files) == 0:
+        only_cases = None
+        if self.__only is not None and len(self.__only) > 0:
+            only_cases = [c + '.yml' for c in self.__only.split(',')]
+            self.debug('Only option is on')
+            self.debug('Run only {}', only_cases)
+
+        for qa_dir, _, cases in os.walk(case_dir):
+            self.debug('Look for test cases in  {}', qa_dir)
+            cases = [c for c in cases if '.yml' in c]
+
+            if len(cases) == 0:
+                self.debug('Found no cases')
                 continue
+
+            self.debug('Found cases: {}', cases)
 
             report = dict()
             report['started'] = helpers.get_current_time_as_str()
-            report['tester'] =  self.__cvs_adapter.get_user_name()
-            report['email'] =  self.__cvs_adapter.get_user_email()
+            report['tester'] = self.__cvs_adapter.get_user_name()
+            report['email'] = self.__cvs_adapter.get_user_email()
             report['cases'] = dict()
 
-            for f in files:
-                with open(os.path.join(qa_dir, f), encoding='utf-8') as case_file:
+            self.debug('Generate the reports header: {}', report)
+
+            for case in cases:
+
+                if only_cases is not None and case not in only_cases:
+                    self.debug('Case {} is not in {}', case, only_cases)
+                    continue
+
+                with open(os.path.join(qa_dir, case), encoding='utf-8') as case_file:
                     data = yaml.load(case_file)
 
-                click.clear()
-                click.echo(
-                    'Start test {}: '.format(f) + click.style('"{}"? [Y/n]'.format(data['description']), bold=True))
+                if not self.__debug:
+                    click.clear()
 
-                report['cases'][f] = dict()
-                report['cases'][f]['description'] = data['description']
-                report['cases'][f]['started'] = helpers.get_current_time_as_str()
+                click.echo(
+                    'Start test {}: '.format(case) + click.style('"{}"? [Y/n]'.format(data['description']), bold=True))
+
+                report['cases'][case] = dict()
+                report['cases'][case]['description'] = data['description']
+                report['cases'][case]['started'] = helpers.get_current_time_as_str()
 
                 answer = input().strip().lower()
                 if answer == 'n':
                     click.secho('SKIPPED', fg='yellow')
-                    report['cases'][f]['status'] = 'skipped'
+                    report['cases'][case]['status'] = 'skipped'
                     continue
 
                 click.secho('SETUP:', bold=True, fg='blue')
@@ -72,19 +97,19 @@ class RunCommandHandler:
                     answer = input().strip().lower()
                     if answer == 'n':
                         click.secho('FAILED', fg='red')
-                        report['cases'][f]['comment'] = input('Comment please the failed step: ').strip()
-                        report['cases'][f]['status'] = 'failed'
-                        report['cases'][f]['failed_step'] = step
-                        report['cases'][f]['failed_action'] = action
-                        report['cases'][f]['failed_expectation'] = expectation
-                        report['cases'][f]['finished'] = helpers.get_current_time_as_str()
+                        report['cases'][case]['comment'] = input('Comment please the failed step: ').strip()
+                        report['cases'][case]['status'] = 'failed'
+                        report['cases'][case]['failed_step'] = step
+                        report['cases'][case]['failed_action'] = action
+                        report['cases'][case]['failed_expectation'] = expectation
+                        report['cases'][case]['finished'] = helpers.get_current_time_as_str()
                         break
                     else:
                         click.secho('PASSED', fg='green')
 
-                if 'status' not in report['cases'][f]:
-                    report['cases'][f]['status'] = 'passed'
-                    report['cases'][f]['finished'] = helpers.get_current_time_as_str()
+                if 'status' not in report['cases'][case]:
+                    report['cases'][case]['status'] = 'passed'
+                    report['cases'][case]['finished'] = helpers.get_current_time_as_str()
 
                 click.secho('TEARDOWN:', bold=True, fg='blue')
                 click.echo('\n'.join(data['teardown']))
@@ -93,13 +118,20 @@ class RunCommandHandler:
 
             report['finished'] = helpers.get_current_time_as_str()
 
+            self.debug('Finish the run report')
+
             run_dir = os.path.join(qa_dir, 'runs')
             if not os.path.exists(run_dir):
+                self.debug('Create dir for run reports', run_dir)
                 os.makedirs(run_dir)
 
             with open(os.path.join(run_dir, time.strftime("%Y%m%d_%H%M%S", time.gmtime()) + '_run.report'),
                       'w', encoding='utf-8') as report_file:
+                self.debug('Save report in file {}', report_file.name)
                 yaml.dump(report, report_file, default_flow_style=False, allow_unicode=True)
 
             # TODO: Should be replaced in special command
             # ReportGenerator('md').generate(self.__qa_dir, report_dir=self.__report_dir)
+
+    def debug(self, msg, *args):
+        click.secho(('[DEBUG] ' + msg).format(*args), fg='magenta') if self.__debug else None

--- a/nitpicker/nitpicker.py
+++ b/nitpicker/nitpicker.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import click
-import os
 import yaml
 from nitpicker.cvs import CVSFactory
 from nitpicker.commands import *
@@ -22,15 +21,17 @@ __cvs_factory__ = CVSFactory()
               help='CVS of the project. Default: git')
 @click.option('--debug', type=bool, default=None, is_flag=True,
               help='Launch in debug mode')
+@click.option('--main-branch', type=str, default=None,
+              help='Main branch in CVS repo where new features are to merge into')
 @click.pass_context
-def main(ctx, qa_dir, no_editor, report_dir, cvs, debug):
+def main(ctx, qa_dir, no_editor, report_dir, cvs, debug, main_branch):
     """
-    Nitpicker is a CLI tool for QA testing
+    Nitpicker is a CLI tool for black-box testing
     """
-    __main_imp__(ctx, qa_dir, no_editor, report_dir, cvs, debug)
+    __main_imp__(ctx, qa_dir, no_editor, report_dir, cvs, debug, main_branch)
 
 
-def __main_imp__(ctx, qa_dir, no_editor, report_dir, cvs, debug, cfg_file='.nitpicker.yml'):
+def __main_imp__(ctx, qa_dir, no_editor, report_dir, cvs, debug, main_branch, cfg_file='.nitpicker.yml'):
     ctx.obj = dict()
     user_config = None
 
@@ -51,7 +52,7 @@ def __main_imp__(ctx, qa_dir, no_editor, report_dir, cvs, debug, cfg_file='.nitp
     init_config_param('no_editor', no_editor, False)
     init_config_param('report_dir', report_dir, '')
     init_config_param('cvs', cvs, 'git')
-    init_config_param('main_branch', None, 'master')
+    init_config_param('main_branch', main_branch, 'master')
     init_config_param('debug', debug, False)
 
 
@@ -100,7 +101,7 @@ def list(ctx):
 
 @main.command()
 @click.argument('test_plan')
-@click.option('--only', type=str, default=None,
+@click.option('--only', '-o', type=str, default=None,
               help='Run only specified cases in the plan')
 @click.pass_context
 def run(ctx, test_plan, only):
@@ -124,7 +125,7 @@ def run(ctx, test_plan, only):
         handler = RunCommandHandler(ctx.obj['qa_dir'],
                                     cvs_adapter=__cvs_factory__.create_cvs_adapter(ctx.obj['cvs']),
                                     test_plan=test_plan,
-                                    report_dir=ctx.obj['report_dir']                                    ,
+                                    report_dir=ctx.obj['report_dir'],
                                     debug=ctx.obj['debug'])
 
         handler.run_test_cases(only=only)

--- a/nitpicker/nitpicker.py
+++ b/nitpicker/nitpicker.py
@@ -20,15 +20,17 @@ __cvs_factory__ = CVSFactory()
               help='Report directory where the QA report should be created: Default: working directory')
 @click.option('--cvs', default=None,
               help='CVS of the project. Default: git')
+@click.option('--debug', type=bool, default=None, is_flag=True,
+              help='Launch in debug mode')
 @click.pass_context
-def main(ctx, qa_dir, no_editor, report_dir, cvs):
+def main(ctx, qa_dir, no_editor, report_dir, cvs, debug):
     """
     Nitpicker is a CLI tool for QA testing
     """
-    __main_imp__(ctx, qa_dir, no_editor, report_dir, cvs)
+    __main_imp__(ctx, qa_dir, no_editor, report_dir, cvs, debug)
 
 
-def __main_imp__(ctx, qa_dir, no_editor, report_dir, cvs, cfg_file='.nitpicker.yml'):
+def __main_imp__(ctx, qa_dir, no_editor, report_dir, cvs, debug, cfg_file='.nitpicker.yml'):
     ctx.obj = dict()
     user_config = None
 
@@ -50,6 +52,7 @@ def __main_imp__(ctx, qa_dir, no_editor, report_dir, cvs, cfg_file='.nitpicker.y
     init_config_param('report_dir', report_dir, '')
     init_config_param('cvs', cvs, 'git')
     init_config_param('main_branch', None, 'master')
+    init_config_param('debug', debug, False)
 
 
 @main.command()
@@ -97,16 +100,23 @@ def list(ctx):
 
 @main.command()
 @click.argument('test_plan')
+@click.option('--only', type=str, default=None,
+              help='Run only specified cases in the plan')
 @click.pass_context
-def run(ctx, test_plan):
+def run(ctx, test_plan, only):
     """
     Run a test plan in the plan tree separated by dot
 
     Example: nitpicker run some_feature.plan_1.set_1
 
-    The program tries to find directory 'qa/some_feature/plan_1/set_2\ in the working directory
+    The program tries to find directory 'qa/some_feature/plan_1/set_2' in the working directory
     and run all the test cases in it. After the running it saves a report in YAML format
     with name '%Y%m%d_%H%M%S_run.report'
+
+    You can run only specified cases in the plan by using option --only. You should list the cases separating
+    them with comma and without spaces
+
+    Example: nitpicker run sum_features --only test1,test2,test3
     """
 
     handler = ValidateCommandHandler(ctx.obj['qa_dir'])
@@ -114,7 +124,9 @@ def run(ctx, test_plan):
         handler = RunCommandHandler(ctx.obj['qa_dir'],
                                     cvs_adapter=__cvs_factory__.create_cvs_adapter(ctx.obj['cvs']),
                                     test_plan=test_plan,
-                                    report_dir=ctx.obj['report_dir'])
+                                    report_dir=ctx.obj['report_dir'],
+                                    only=only,
+                                    debug=ctx.obj['debug'])
 
         handler.run_test_cases()
 

--- a/nitpicker/nitpicker.py
+++ b/nitpicker/nitpicker.py
@@ -124,11 +124,10 @@ def run(ctx, test_plan, only):
         handler = RunCommandHandler(ctx.obj['qa_dir'],
                                     cvs_adapter=__cvs_factory__.create_cvs_adapter(ctx.obj['cvs']),
                                     test_plan=test_plan,
-                                    report_dir=ctx.obj['report_dir'],
-                                    only=only,
+                                    report_dir=ctx.obj['report_dir']                                    ,
                                     debug=ctx.obj['debug'])
 
-        handler.run_test_cases()
+        handler.run_test_cases(only=only)
 
     else:
         exit(1)

--- a/qa/commands/run/run_only_test.yml
+++ b/qa/commands/run/run_only_test.yml
@@ -1,0 +1,19 @@
+created: 2018-10-06 11:03:08
+author: Aleksey Timin
+email: atimin@gmail.com
+description: Run only one test from a test plan
+tags: commands
+setup:
+- Run command 'python -m nitpicker -d test_qa add test_test_case_1 -p commands.command_1'
+- Save the case without changes
+- Close the editor
+- Run command 'python -m nitpicker -d test_qa add test_test_case_2 -p commands.command_2'
+- Save the case without changes
+- Close the editor
+steps:
+- Run command 'python -m nitpicker -d test_qa run commands --only test_test_case_2'
+  => You should see message 'Start test test_test_case_2.yml - None? [Y/n]'
+- Pass all steps and press any key at the end
+  => The run is finished (no more tests)
+teardown:
+- Delete test_qa directory

--- a/qa/commands/run/runs/20181006_111142_run.report
+++ b/qa/commands/run/runs/20181006_111142_run.report
@@ -1,0 +1,15 @@
+cases:
+  run_only_test.yml:
+    description: Run only one test from a test plan
+    finished: '2018-10-06 11:10:41'
+    started: '2018-10-06 11:09:03'
+    status: passed
+  run_test_plan.yml:
+    description: Run a test plan and pass all tests
+    finished: '2018-10-06 11:11:41'
+    started: '2018-10-06 11:10:44'
+    status: passed
+email: atimin@gmail.com
+finished: '2018-10-06 11:11:42'
+started: '2018-10-06 11:09:03'
+tester: Aleksey Timin

--- a/tests/fixtures/.nitpicker.yml
+++ b/tests/fixtures/.nitpicker.yml
@@ -2,3 +2,5 @@ qa_dir:     test_qa
 no_editor:  true
 report_dir: test_report
 cvs:        test_cvs
+main_branch: test_branch
+debug: true

--- a/tests/test_cfg_file.py
+++ b/tests/test_cfg_file.py
@@ -14,37 +14,48 @@ class TestCfgFile(unittest.TestCase):
         self.__ctx = Context()
 
     def test_load_settings_from_cfg_file(self):
-        __main_imp__(self.__ctx, qa_dir=None, no_editor=None, report_dir=None, cvs=None,
+        __main_imp__(self.__ctx, qa_dir=None, no_editor=None, report_dir=None, cvs=None, debug=None, main_branch=None,
                      cfg_file=self.__cfg_file)
 
         self.assertEqual(self.__ctx.obj['qa_dir'], 'test_qa')
         self.assertEqual(self.__ctx.obj['no_editor'], True)
         self.assertEqual(self.__ctx.obj['report_dir'], 'test_report')
         self.assertEqual(self.__ctx.obj['cvs'], 'test_cvs')
+        self.assertEqual(self.__ctx.obj['debug'],  True)
+        self.assertEqual(self.__ctx.obj['main_branch'], 'test_branch')
 
     def test_command_option_override_cfg_file(self):
         __main_imp__(self.__ctx, qa_dir='option_dir', no_editor=False, report_dir='option_report', cvs='option_cvs',
+                     debug=False, main_branch='option_branch',
                      cfg_file=self.__cfg_file)
 
         self.assertEqual(self.__ctx.obj['qa_dir'], 'option_dir')
         self.assertEqual(self.__ctx.obj['no_editor'], False)
         self.assertEqual(self.__ctx.obj['report_dir'], 'option_report')
         self.assertEqual(self.__ctx.obj['cvs'], 'option_cvs')
+        self.assertEqual(self.__ctx.obj['debug'], False)
+        self.assertEqual(self.__ctx.obj['main_branch'], 'option_branch')
 
     def test_using_default_settings_if_config_not_exists(self):
         __main_imp__(self.__ctx, qa_dir=None, no_editor=None, report_dir=None, cvs=None,
+                     debug=None, main_branch=None,
                      cfg_file='xxxxxxxxxxx')
 
         self.assertEqual(self.__ctx.obj['qa_dir'], 'qa')
         self.assertEqual(self.__ctx.obj['no_editor'], False)
         self.assertEqual(self.__ctx.obj['report_dir'], '')
         self.assertEqual(self.__ctx.obj['cvs'], 'git')
+        self.assertEqual(self.__ctx.obj['debug'], False)
+        self.assertEqual(self.__ctx.obj['main_branch'], 'master')
 
     def test_using_default_settings_if_config_has_no_valid_settings(self):
         __main_imp__(self.__ctx, qa_dir=None, no_editor=None, report_dir=None, cvs=None,
+                     debug=None, main_branch=None,
                      cfg_file='.nitpicker.yml.wrong')
 
         self.assertEqual(self.__ctx.obj['qa_dir'], 'qa')
         self.assertEqual(self.__ctx.obj['no_editor'], False)
         self.assertEqual(self.__ctx.obj['report_dir'], '')
         self.assertEqual(self.__ctx.obj['cvs'], 'git')
+        self.assertEqual(self.__ctx.obj['debug'], False)
+        self.assertEqual(self.__ctx.obj['main_branch'], 'master')


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR implements option --only  of 'run' command which provides to run some tests in the test plan separately.

* **What is the current behavior?** (You can also link to an open issue here)
Before a user can run only a whole test plan with all its tests.


* **What is the new behavior (if this is a feature change)?**
Now a user can run only tests that they needs

`nitpicker run test_plan --only=test1,test2`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes.


* **Other information**:
